### PR TITLE
feat: BOOK-003-T3 - Implement Publisher CRUD operations and management

### DIFF
--- a/library-backend/src/main/java/com/library/controller/PublisherController.java
+++ b/library-backend/src/main/java/com/library/controller/PublisherController.java
@@ -1,0 +1,181 @@
+package com.library.controller;
+
+import com.library.dto.BaseResponse;
+import com.library.dto.CreatePublisherRequestDTO;
+import com.library.dto.PublisherDTO;
+import com.library.dto.PublisherDetailDTO;
+import com.library.dto.UpdatePublisherRequestDTO;
+import com.library.service.PublisherService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1")
+@Slf4j
+@Tag(name = "Publisher Management", description = "APIs for managing book publishers")
+@CrossOrigin(origins = "*")
+public class PublisherController {
+    
+    private final PublisherService publisherService;
+    
+    public PublisherController(PublisherService publisherService) {
+        this.publisherService = publisherService;
+    }
+    
+    // Public endpoints
+    
+    @GetMapping("/publishers")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get all publishers with pagination", description = "Retrieve paginated list of all publishers")
+    public BaseResponse<Page<PublisherDTO>> getAllPublishers(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "Sort field") @RequestParam(defaultValue = "name") String sortBy,
+            @Parameter(description = "Sort direction") @RequestParam(defaultValue = "asc") String sortDir) {
+        log.info("GET /api/v1/publishers - Fetching publishers with pagination");
+        
+        Sort.Direction direction = sortDir.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+        
+        Page<PublisherDTO> publishers = publisherService.getAllPublishers(pageable);
+        return BaseResponse.success(publishers);
+    }
+    
+    @GetMapping("/publishers/{publisherId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get publisher by ID", description = "Retrieve detailed information about a specific publisher")
+    public BaseResponse<PublisherDetailDTO> getPublisherById(
+            @Parameter(description = "Publisher ID") @PathVariable Long publisherId) {
+        log.info("GET /api/v1/publishers/{} - Fetching publisher details", publisherId);
+        
+        PublisherDetailDTO publisher = publisherService.getPublisherById(publisherId);
+        return BaseResponse.success(publisher);
+    }
+    
+    @GetMapping("/publishers/{publisherId}/books")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get publisher with books", description = "Retrieve publisher information including their books")
+    public BaseResponse<PublisherDetailDTO> getPublisherWithBooks(
+            @Parameter(description = "Publisher ID") @PathVariable Long publisherId) {
+        log.info("GET /api/v1/publishers/{}/books - Fetching publisher with books", publisherId);
+        
+        PublisherDetailDTO publisher = publisherService.getPublisherWithBooks(publisherId);
+        return BaseResponse.success(publisher);
+    }
+    
+    @GetMapping("/publishers/search")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Search publishers by name", description = "Search publishers by name (partial match)")
+    public BaseResponse<List<PublisherDTO>> searchPublishersByName(
+            @Parameter(description = "Publisher name") @RequestParam String name) {
+        log.info("GET /api/v1/publishers/search - Searching publishers by name: {}", name);
+        
+        List<PublisherDTO> publishers = publisherService.searchPublishersByName(name);
+        return BaseResponse.success(publishers);
+    }
+    
+    @GetMapping("/publishers/established")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get publishers by established year range", description = "Retrieve publishers established within a year range")
+    public BaseResponse<List<PublisherDTO>> getPublishersByEstablishedYear(
+            @Parameter(description = "Start year") @RequestParam Integer startYear,
+            @Parameter(description = "End year") @RequestParam Integer endYear) {
+        log.info("GET /api/v1/publishers/established - Fetching publishers between {} and {}", startYear, endYear);
+        
+        List<PublisherDTO> publishers = publisherService.getPublishersByEstablishedYear(startYear, endYear);
+        return BaseResponse.success(publishers);
+    }
+    
+    @GetMapping("/publishers/active")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Get most active publishers", description = "Retrieve publishers with most books")
+    public BaseResponse<List<PublisherDTO>> getMostActivePublishers(
+            @Parameter(description = "Number of publishers to return") @RequestParam(defaultValue = "10") int limit) {
+        log.info("GET /api/v1/publishers/active - Fetching most active publishers with limit: {}", limit);
+        
+        List<PublisherDTO> publishers = publisherService.getMostActivePublishers(limit);
+        return BaseResponse.success(publishers);
+    }
+    
+    // Admin endpoints
+    
+    @PostMapping("/admin/publishers")
+    @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasRole('LIBRARIAN') or hasRole('ADMIN')")
+    @Operation(summary = "Create new publisher", description = "Create a new publisher (Admin/Librarian only)")
+    public BaseResponse<PublisherDetailDTO> createPublisher(
+            @RequestBody @Validated CreatePublisherRequestDTO createRequest) {
+        log.info("POST /api/v1/admin/publishers - Creating new publisher: {}", createRequest.getName());
+        
+        PublisherDetailDTO publisher = publisherService.createPublisher(createRequest);
+        return BaseResponse.success(publisher);
+    }
+    
+    @PutMapping("/admin/publishers/{publisherId}")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('LIBRARIAN') or hasRole('ADMIN')")
+    @Operation(summary = "Update publisher", description = "Update an existing publisher (Admin/Librarian only)")
+    public BaseResponse<PublisherDetailDTO> updatePublisher(
+            @Parameter(description = "Publisher ID") @PathVariable Long publisherId,
+            @RequestBody @Validated UpdatePublisherRequestDTO updateRequest) {
+        log.info("PUT /api/v1/admin/publishers/{} - Updating publisher", publisherId);
+        
+        PublisherDetailDTO publisher = publisherService.updatePublisher(publisherId, updateRequest);
+        return BaseResponse.success(publisher);
+    }
+    
+    @DeleteMapping("/admin/publishers/{publisherId}")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('LIBRARIAN') or hasRole('ADMIN')")
+    @Operation(summary = "Delete publisher", description = "Delete a publisher (Admin/Librarian only)")
+    public BaseResponse<String> deletePublisher(
+            @Parameter(description = "Publisher ID") @PathVariable Long publisherId) {
+        log.info("DELETE /api/v1/admin/publishers/{} - Deleting publisher", publisherId);
+        
+        publisherService.deletePublisher(publisherId);
+        return BaseResponse.success("Publisher deleted successfully");
+    }
+    
+    @GetMapping("/admin/publishers")
+    @ResponseStatus(HttpStatus.OK)
+    @PreAuthorize("hasRole('LIBRARIAN') or hasRole('ADMIN')")
+    @Operation(summary = "Get all publishers for admin", description = "Retrieve all publishers with admin details (Admin/Librarian only)")
+    public BaseResponse<Page<PublisherDTO>> getAllPublishersForAdmin(
+            @Parameter(description = "Page number (0-based)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size") @RequestParam(defaultValue = "50") int size,
+            @Parameter(description = "Sort field") @RequestParam(defaultValue = "name") String sortBy,
+            @Parameter(description = "Sort direction") @RequestParam(defaultValue = "asc") String sortDir) {
+        log.info("GET /api/v1/admin/publishers - Fetching publishers for admin");
+        
+        Sort.Direction direction = sortDir.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortBy));
+        
+        Page<PublisherDTO> publishers = publisherService.getAllPublishers(pageable);
+        return BaseResponse.success(publishers);
+    }
+    
+    // Utility endpoints
+    
+    @GetMapping("/publishers/check-name")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "Check publisher name availability", description = "Check if a publisher name is available")
+    public BaseResponse<Boolean> checkNameAvailability(
+            @Parameter(description = "Publisher name to check") @RequestParam String name) {
+        log.debug("GET /api/v1/publishers/check-name - Checking availability for name: {}", name);
+        
+        boolean exists = publisherService.existsByName(name);
+        return BaseResponse.success(!exists);
+    }
+}

--- a/library-backend/src/main/java/com/library/dto/CreatePublisherRequestDTO.java
+++ b/library-backend/src/main/java/com/library/dto/CreatePublisherRequestDTO.java
@@ -1,0 +1,39 @@
+package com.library.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePublisherRequestDTO {
+    
+    @NotBlank(message = "Publisher name is required")
+    @Size(min = 2, max = 100, message = "Publisher name must be between 2 and 100 characters")
+    private String name;
+    
+    @Size(max = 500, message = "Address cannot exceed 500 characters")
+    private String address;
+    
+    @Size(max = 255, message = "Contact info cannot exceed 255 characters")
+    private String contactInfo;
+    
+    @Size(max = 255, message = "Website URL cannot exceed 255 characters")
+    private String website;
+    
+    @Email(message = "Invalid email format")
+    @Size(max = 100, message = "Email cannot exceed 100 characters")
+    private String email;
+    
+    @Min(value = 1400, message = "Established year must be after 1400")
+    @Max(value = 9999, message = "Invalid established year")
+    private Integer establishedYear;
+}

--- a/library-backend/src/main/java/com/library/dto/PublisherDetailDTO.java
+++ b/library-backend/src/main/java/com/library/dto/PublisherDetailDTO.java
@@ -6,12 +6,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PublisherDTO {
+public class PublisherDetailDTO {
     private Long id;
     private String name;
     private String address;
@@ -23,6 +24,7 @@ public class PublisherDTO {
     
     // Statistics
     private Long bookCount;
+    private List<BookDTO> books;
     
     // Computed fields
     private Integer yearsInBusiness;

--- a/library-backend/src/main/java/com/library/dto/UpdatePublisherRequestDTO.java
+++ b/library-backend/src/main/java/com/library/dto/UpdatePublisherRequestDTO.java
@@ -1,0 +1,37 @@
+package com.library.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdatePublisherRequestDTO {
+    
+    @Size(min = 2, max = 100, message = "Publisher name must be between 2 and 100 characters")
+    private String name;
+    
+    @Size(max = 500, message = "Address cannot exceed 500 characters")
+    private String address;
+    
+    @Size(max = 255, message = "Contact info cannot exceed 255 characters")
+    private String contactInfo;
+    
+    @Size(max = 255, message = "Website URL cannot exceed 255 characters")
+    private String website;
+    
+    @Email(message = "Invalid email format")
+    @Size(max = 100, message = "Email cannot exceed 100 characters")
+    private String email;
+    
+    @Min(value = 1400, message = "Established year must be after 1400")
+    @Max(value = 9999, message = "Invalid established year")
+    private Integer establishedYear;
+}

--- a/library-backend/src/main/java/com/library/mapper/PublisherMapper.java
+++ b/library-backend/src/main/java/com/library/mapper/PublisherMapper.java
@@ -1,8 +1,12 @@
 package com.library.mapper;
 
+import com.library.dto.CreatePublisherRequestDTO;
 import com.library.dto.PublisherDTO;
+import com.library.dto.PublisherDetailDTO;
+import com.library.dto.UpdatePublisherRequestDTO;
 import com.library.entity.Publisher;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
 import java.util.List;
@@ -10,11 +14,24 @@ import java.util.List;
 @Mapper(componentModel = "spring")
 public interface PublisherMapper {
     
+    @Mapping(target = "bookCount", ignore = true)
+    @Mapping(target = "yearsInBusiness", ignore = true)
     PublisherDTO toDTO(Publisher publisher);
     
-    Publisher toEntity(PublisherDTO publisherDTO);
+    @Mapping(target = "bookCount", ignore = true)
+    @Mapping(target = "books", ignore = true)
+    @Mapping(target = "yearsInBusiness", ignore = true)
+    PublisherDetailDTO toDetailDTO(Publisher publisher);
+    
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "books", ignore = true)
+    Publisher toEntity(CreatePublisherRequestDTO createRequest);
     
     List<PublisherDTO> toDTOList(List<Publisher> publishers);
     
-    void updateEntityFromDTO(PublisherDTO publisherDTO, @MappingTarget Publisher publisher);
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "createdAt", ignore = true)
+    @Mapping(target = "books", ignore = true)
+    void updateEntityFromDTO(UpdatePublisherRequestDTO updateRequest, @MappingTarget Publisher publisher);
 }

--- a/library-backend/src/main/java/com/library/service/PublisherService.java
+++ b/library-backend/src/main/java/com/library/service/PublisherService.java
@@ -1,0 +1,39 @@
+package com.library.service;
+
+import com.library.dto.CreatePublisherRequestDTO;
+import com.library.dto.PublisherDTO;
+import com.library.dto.PublisherDetailDTO;
+import com.library.dto.UpdatePublisherRequestDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface PublisherService {
+    
+    // CRUD Operations
+    PublisherDetailDTO createPublisher(CreatePublisherRequestDTO createRequest);
+    
+    PublisherDetailDTO getPublisherById(Long id);
+    
+    PublisherDetailDTO getPublisherWithBooks(Long id);
+    
+    PublisherDetailDTO updatePublisher(Long id, UpdatePublisherRequestDTO updateRequest);
+    
+    void deletePublisher(Long id);
+    
+    // Listing methods
+    Page<PublisherDTO> getAllPublishers(Pageable pageable);
+    
+    List<PublisherDTO> searchPublishersByName(String name);
+    
+    List<PublisherDTO> getPublishersByEstablishedYear(Integer startYear, Integer endYear);
+    
+    List<PublisherDTO> getMostActivePublishers(int limit);
+    
+    // Validation methods
+    boolean existsByName(String name);
+    
+    // Statistics
+    Long getBookCount(Long publisherId);
+}

--- a/library-backend/src/main/java/com/library/service/impl/PublisherServiceImpl.java
+++ b/library-backend/src/main/java/com/library/service/impl/PublisherServiceImpl.java
@@ -1,0 +1,203 @@
+package com.library.service.impl;
+
+import com.library.dto.BookDTO;
+import com.library.dto.CreatePublisherRequestDTO;
+import com.library.dto.PublisherDTO;
+import com.library.dto.PublisherDetailDTO;
+import com.library.dto.UpdatePublisherRequestDTO;
+import com.library.entity.Publisher;
+import com.library.exception.BookNotFoundException;
+import com.library.exception.DuplicateBookException;
+import com.library.mapper.BookMapper;
+import com.library.mapper.PublisherMapper;
+import com.library.repository.PublisherRepository;
+import com.library.service.PublisherService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Year;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PublisherServiceImpl implements PublisherService {
+    
+    private final PublisherRepository publisherRepository;
+    private final PublisherMapper publisherMapper;
+    private final BookMapper bookMapper;
+    
+    @Override
+    @Transactional
+    public PublisherDetailDTO createPublisher(CreatePublisherRequestDTO createRequest) {
+        log.info("Creating new publisher with name: {}", createRequest.getName());
+        
+        // Validate unique name
+        if (publisherRepository.existsByName(createRequest.getName())) {
+            throw new DuplicateBookException("Publisher with name '" + createRequest.getName() + "' already exists");
+        }
+        
+        // Validate established year if provided
+        if (createRequest.getEstablishedYear() != null) {
+            int currentYear = Year.now().getValue();
+            if (createRequest.getEstablishedYear() > currentYear) {
+                throw new IllegalArgumentException("Established year cannot be in the future");
+            }
+        }
+        
+        Publisher publisher = publisherMapper.toEntity(createRequest);
+        publisher = publisherRepository.save(publisher);
+        
+        log.info("Successfully created publisher with id: {}", publisher.getId());
+        return enrichPublisherDetailDTO(publisherMapper.toDetailDTO(publisher));
+    }
+    
+    @Override
+    public PublisherDetailDTO getPublisherById(Long id) {
+        log.debug("Fetching publisher by id: {}", id);
+        Publisher publisher = publisherRepository.findById(id)
+                .orElseThrow(() -> new BookNotFoundException("Publisher not found with id: " + id));
+        
+        return enrichPublisherDetailDTO(publisherMapper.toDetailDTO(publisher));
+    }
+    
+    @Override
+    public PublisherDetailDTO getPublisherWithBooks(Long id) {
+        log.debug("Fetching publisher with books by id: {}", id);
+        Publisher publisher = publisherRepository.findByIdWithBooks(id)
+                .orElseThrow(() -> new BookNotFoundException("Publisher not found with id: " + id));
+        
+        PublisherDetailDTO dto = enrichPublisherDetailDTO(publisherMapper.toDetailDTO(publisher));
+        
+        // Map books
+        List<BookDTO> books = publisher.getBooks().stream()
+                .map(bookMapper::toDTO)
+                .toList();
+        dto.setBooks(books);
+        
+        return dto;
+    }
+    
+    @Override
+    @Transactional
+    public PublisherDetailDTO updatePublisher(Long id, UpdatePublisherRequestDTO updateRequest) {
+        log.info("Updating publisher with id: {}", id);
+        
+        Publisher publisher = publisherRepository.findById(id)
+                .orElseThrow(() -> new BookNotFoundException("Publisher not found with id: " + id));
+        
+        // Validate unique name if changed
+        if (updateRequest.getName() != null && 
+            !updateRequest.getName().equals(publisher.getName()) &&
+            publisherRepository.existsByName(updateRequest.getName())) {
+            throw new DuplicateBookException("Publisher with name '" + updateRequest.getName() + "' already exists");
+        }
+        
+        // Validate established year if provided
+        if (updateRequest.getEstablishedYear() != null) {
+            int currentYear = Year.now().getValue();
+            if (updateRequest.getEstablishedYear() > currentYear) {
+                throw new IllegalArgumentException("Established year cannot be in the future");
+            }
+        }
+        
+        publisherMapper.updateEntityFromDTO(updateRequest, publisher);
+        publisher = publisherRepository.save(publisher);
+        
+        log.info("Successfully updated publisher with id: {}", id);
+        return enrichPublisherDetailDTO(publisherMapper.toDetailDTO(publisher));
+    }
+    
+    @Override
+    @Transactional
+    public void deletePublisher(Long id) {
+        log.info("Deleting publisher with id: {}", id);
+        
+        Publisher publisher = publisherRepository.findById(id)
+                .orElseThrow(() -> new BookNotFoundException("Publisher not found with id: " + id));
+        
+        // Check if publisher has books
+        Long bookCount = publisherRepository.countBooksByPublisherId(id);
+        if (bookCount > 0) {
+            throw new IllegalStateException("Cannot delete publisher: " + bookCount + " books are associated with this publisher");
+        }
+        
+        publisherRepository.delete(publisher);
+        log.info("Successfully deleted publisher with id: {}", id);
+    }
+    
+    @Override
+    public Page<PublisherDTO> getAllPublishers(Pageable pageable) {
+        log.debug("Fetching all publishers with pagination");
+        Page<Publisher> publisherPage = publisherRepository.findAll(pageable);
+        return publisherPage.map(this::enrichPublisherDTO);
+    }
+    
+    @Override
+    public List<PublisherDTO> searchPublishersByName(String name) {
+        log.debug("Searching publishers by name: {}", name);
+        List<Publisher> publishers = publisherRepository.findByNameContainingIgnoreCase(name);
+        return publishers.stream()
+                .map(this::enrichPublisherDTO)
+                .toList();
+    }
+    
+    @Override
+    public List<PublisherDTO> getPublishersByEstablishedYear(Integer startYear, Integer endYear) {
+        log.debug("Fetching publishers established between {} and {}", startYear, endYear);
+        List<Publisher> publishers = publisherRepository.findByEstablishedYearBetween(startYear, endYear);
+        return publishers.stream()
+                .map(this::enrichPublisherDTO)
+                .toList();
+    }
+    
+    @Override
+    public List<PublisherDTO> getMostActivePublishers(int limit) {
+        log.debug("Fetching most active publishers with limit: {}", limit);
+        Pageable pageable = PageRequest.of(0, limit);
+        List<Publisher> publishers = publisherRepository.findMostActivePublishers(pageable);
+        return publishers.stream()
+                .map(this::enrichPublisherDTO)
+                .toList();
+    }
+    
+    @Override
+    public boolean existsByName(String name) {
+        return publisherRepository.existsByName(name);
+    }
+    
+    @Override
+    public Long getBookCount(Long publisherId) {
+        return publisherRepository.countBooksByPublisherId(publisherId);
+    }
+    
+    // Helper methods
+    
+    private PublisherDTO enrichPublisherDTO(Publisher publisher) {
+        PublisherDTO dto = publisherMapper.toDTO(publisher);
+        dto.setBookCount(publisherRepository.countBooksByPublisherId(publisher.getId()));
+        dto.setYearsInBusiness(calculateYearsInBusiness(publisher.getEstablishedYear()));
+        return dto;
+    }
+    
+    private PublisherDetailDTO enrichPublisherDetailDTO(PublisherDetailDTO dto) {
+        dto.setBookCount(publisherRepository.countBooksByPublisherId(dto.getId()));
+        dto.setYearsInBusiness(calculateYearsInBusiness(dto.getEstablishedYear()));
+        return dto;
+    }
+    
+    private Integer calculateYearsInBusiness(Integer establishedYear) {
+        if (establishedYear == null) {
+            return null;
+        }
+        
+        int currentYear = Year.now().getValue();
+        return currentYear - establishedYear;
+    }
+}


### PR DESCRIPTION
- Add CreatePublisherRequestDTO, UpdatePublisherRequestDTO, PublisherDetailDTO
- Update PublisherDTO with additional fields (establishedYear, createdAt, bookCount, yearsInBusiness)
- Update PublisherMapper with comprehensive mapping methods for new DTOs
- Implement PublisherService interface with full CRUD operations
- Add PublisherServiceImpl with business logic and validation
- Implement PublisherController with public and admin endpoints
- Support for publisher search by name and established year range
- Add computed field for years in business calculation
- Include most active publishers and name availability checking
- Full validation for established year and business rules